### PR TITLE
feat: add the ability to use a custom message

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Danger method to call when the commit message does not pass the linter
 Type:
 
 ```ts
-(errors: LintRuleOutcome[], commitMessage: string) => string;
+(ruleOutcome: LintOutcome, commitMessage: string) => string;
 ```
 
 Default:
@@ -66,10 +66,10 @@ Example:
 
 ```ts
 const messageReplacer = (
-  errors: LintRuleOutcome[],
+  ruleOutcome: LintOutcome,
   commitMessage: string
 ): string => {
-  const errorsDescription = errors
+  const errorsDescription = ruleOutcome.errors
     .map((error) => `<li>${error.message}</li>`)
     .join('');
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ const messageReplacer = (
 };
 ```
 
-<img width="346" alt="Screenshot 2023-01-04 at 07 42 48" src="https://user-images.githubusercontent.com/42243887/210506880-a7510e8c-7d48-4d18-b2f0-95547ecd5882.png">
-
 ## Changelog
 
 See the GitHub [release history](https://github.com/bearalliance/danger-plugin-conventional-commitlint/releases).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Type: `String`<br>
 Choices: `'fail' | 'warn' | 'message'`<br>
 danger method to call when the commit message does not pass the linter
 
+#### customMessage
+
+Type: `{ prefix?: string; suffix?: string; }`<br>
+Mandatory: `false`<br>
+functionality to add a prefix or suffix to the outputted message
+
 ## Changelog
 
 See the GitHub [release history](https://github.com/bearalliance/danger-plugin-conventional-commitlint/releases).

--- a/README.md
+++ b/README.md
@@ -38,17 +38,46 @@ commitlint([rules], [options])
 
 ### Options
 
-#### severity
+#### `severity`
 
 Type: `String`<br>
 Choices: `'fail' | 'warn' | 'message'`<br>
-danger method to call when the commit message does not pass the linter
+Default: `'fail'`<br>
+Danger method to call when the commit message does not pass the linter
 
-#### customMessage
+---
 
-Type: `{ prefix?: string; suffix?: string; }`<br>
-Mandatory: `false`<br>
-functionality to add a prefix or suffix to the outputted message
+#### `messageReplacer`
+
+Type:
+
+```ts
+(errors: LintRuleOutcome[], commitMessage: string) => string;
+```
+
+Default:
+
+```
+There is a problem with the commit message > [Commit message] - [Error Messages]
+```
+
+Method to add a custom message. When not passed, a default message is shown.
+Example:
+
+```ts
+const messageReplacer = (
+  errors: LintRuleOutcome[],
+  commitMessage: string
+): string => {
+  const errorsDescription = errors
+    .map((error) => `<li>${error.message}</li>`)
+    .join('');
+
+  return `<p>Commit message: <b>"${commitMessage}"</b></p><ul>${errorsDescription}</ul> Suffix after commit message`;
+};
+```
+
+<img width="346" alt="Screenshot 2023-01-04 at 07 42 48" src="https://user-images.githubusercontent.com/42243887/210506880-a7510e8c-7d48-4d18-b2f0-95547ecd5882.png">
 
 ## Changelog
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,5 @@
 import { rules } from '@commitlint/config-conventional';
-import { LintRuleOutcome } from '@commitlint/types';
+import type { ReplacerContext } from './index';
 import commitlint from './index';
 
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
@@ -52,11 +52,11 @@ describe('commitlint', () => {
           const customMessageSuffix =
             'To learn more about Conventional Commits, visit <a href="https://www.conventionalcommits.org">https://www.conventionalcommits.org/</a>';
 
-          const messageReplacer = (
-            errors: LintRuleOutcome[],
-            commitMessage: string
-          ): string => {
-            const errorsDescription = errors
+          const messageReplacer = ({
+            ruleOutcome,
+            commitMessage,
+          }: ReplacerContext): string => {
+            const errorsDescription = ruleOutcome.errors
               .map((error) => `- ${error.message}`)
               .join('<br>');
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -44,6 +44,45 @@ describe('commitlint', () => {
           );
         });
       });
+
+      describe('with default config and custom message prefix and suffix', () => {
+        it('should generate a message with default prefix and custom suffix, and fail', async () => {
+          const customMessage = {
+            suffix:
+              'To learn more about Conventional Commits, visit <a href="https://www.conventionalcommits.org">https://www.conventionalcommits.org/</a>',
+          };
+          await commitlint(rules, { customMessage });
+          expect(global.fail).toHaveBeenCalledTimes(1);
+          expect(global.fail).toHaveBeenCalledWith(
+            `There is a problem with the commit message\n> foo\n- subject may not be empty\n- type may not be empty ${customMessage.suffix}`
+          );
+        });
+
+        it('should generate a message with custom prefix and custom suffix, and fail', async () => {
+          const customMessage = {
+            prefix: 'Wrong commit message:',
+            suffix:
+              'To learn more about Conventional Commits, visit <a href="https://www.conventionalcommits.org">https://www.conventionalcommits.org/</a>',
+          };
+          await commitlint(rules, { customMessage });
+          expect(global.fail).toHaveBeenCalledTimes(1);
+          expect(global.fail).toHaveBeenCalledWith(
+            `${customMessage.prefix} foo\n- subject may not be empty\n- type may not be empty ${customMessage.suffix}`
+          );
+        });
+
+        it('should generate a message with custom prefix and no suffix, and fail', async () => {
+          const customMessage = {
+            prefix: 'Wrong commit message:',
+          };
+          await commitlint(rules, { customMessage });
+          expect(global.fail).toHaveBeenCalledTimes(1);
+          expect(global.fail).toHaveBeenCalledWith(
+            `${customMessage.prefix} foo\n- subject may not be empty\n- type may not be empty`
+          );
+        });
+      });
+
       describe('with warn configured', () => {
         it('should generate a message and fail', async () => {
           await commitlint(rules, { severity: 'warn' });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 import { rules } from '@commitlint/config-conventional';
+import { LintRuleOutcome } from '@commitlint/types';
 import commitlint from './index';
 
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
@@ -45,40 +46,27 @@ describe('commitlint', () => {
         });
       });
 
-      describe('with default config and custom message prefix and suffix', () => {
-        it('should generate a message with default prefix and custom suffix, and fail', async () => {
-          const customMessage = {
-            suffix:
-              'To learn more about Conventional Commits, visit <a href="https://www.conventionalcommits.org">https://www.conventionalcommits.org/</a>',
-          };
-          await commitlint(rules, { customMessage });
-          expect(global.fail).toHaveBeenCalledTimes(1);
-          expect(global.fail).toHaveBeenCalledWith(
-            `There is a problem with the commit message\n> foo\n- subject may not be empty\n- type may not be empty ${customMessage.suffix}`
-          );
-        });
+      describe('with custom messageReplacer function', () => {
+        it('should generate a custom message, and fail', async () => {
+          const customMessagePrefix = `This is a beginning of the failure message:`;
+          const customMessageSuffix =
+            'To learn more about Conventional Commits, visit <a href="https://www.conventionalcommits.org">https://www.conventionalcommits.org/</a>';
 
-        it('should generate a message with custom prefix and custom suffix, and fail', async () => {
-          const customMessage = {
-            prefix: 'Wrong commit message:',
-            suffix:
-              'To learn more about Conventional Commits, visit <a href="https://www.conventionalcommits.org">https://www.conventionalcommits.org/</a>',
-          };
-          await commitlint(rules, { customMessage });
-          expect(global.fail).toHaveBeenCalledTimes(1);
-          expect(global.fail).toHaveBeenCalledWith(
-            `${customMessage.prefix} foo\n- subject may not be empty\n- type may not be empty ${customMessage.suffix}`
-          );
-        });
+          const messageReplacer = (
+            errors: LintRuleOutcome[],
+            commitMessage: string
+          ): string => {
+            const errorsDescription = errors
+              .map((error) => `- ${error.message}`)
+              .join('<br>');
 
-        it('should generate a message with custom prefix and no suffix, and fail', async () => {
-          const customMessage = {
-            prefix: 'Wrong commit message:',
+            return `${customMessagePrefix} ${commitMessage}<br>${errorsDescription}<br>${customMessageSuffix}`;
           };
-          await commitlint(rules, { customMessage });
+
+          await commitlint(rules, { messageReplacer });
           expect(global.fail).toHaveBeenCalledTimes(1);
           expect(global.fail).toHaveBeenCalledWith(
-            `${customMessage.prefix} foo\n- subject may not be empty\n- type may not be empty`
+            `${customMessagePrefix} foo<br>- subject may not be empty<br>- type may not be empty<br>${customMessageSuffix}`
           );
         });
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,17 +30,19 @@ interface Rules {
   'type-enum': Array<string[] | number | string>;
 }
 
+const messageReplacer = ({ ruleOutcome, commitMessage }) => {
+  let failureMessage = `There is a problem with the commit message\n> ${commitMessage}`;
+
+  ruleOutcome.errors.forEach((error) => {
+    failureMessage = `${failureMessage}\n- ${error.message}`;
+  });
+
+  return failureMessage;
+};
+
 const defaultConfig = {
   severity: 'fail' as const,
-  messageReplacer: ({ ruleOutcome, commitMessage }) => {
-    let failureMessage = `There is a problem with the commit message\n> ${commitMessage}`;
-
-    ruleOutcome.errors.forEach((error) => {
-      failureMessage = `${failureMessage}\n- ${error.message}`;
-    });
-
-    return failureMessage;
-  },
+  messageReplacer,
 };
 
 export default async function commitlint(


### PR DESCRIPTION
Hi @BearAlliance, 

Don't know if you'll like this idea but I thought I'd open a PR anyway :)
I was using your plugin in a project at work and a colleague of mine asked if we can modify the message shown when commit linting failed so we could also include a link to Conventional Commit website. I realised I couldn't change the message as it is and tried forking the repo and modifying it a bit to allow changing the message (either append something in the end or change the default first part of it). 

