### PR TITLE
ci: only run ci builds for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - beta
+  pull_request:
+    branches:
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
no need to run them twice